### PR TITLE
fix(event): enrich user info for certain keycloak events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.aznamier.keycloak.event.provider</groupId>
     <artifactId>keycloak-to-rabbit-tributech-mod</artifactId>
     <packaging>jar</packaging>
-	<version>1.0</version>
+	<version>1.1</version>
     
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <groupId>com.github.aznamier.keycloak.event.provider</groupId>
-    <artifactId>keycloak-to-rabbit</artifactId>
+    <artifactId>keycloak-to-rabbit-tributech-mod</artifactId>
     <packaging>jar</packaging>
 	<version>1.0</version>
     
@@ -18,8 +18,8 @@
 	<distributionManagement>
 	   <repository>
 	     <id>github</id>
-	     <name>GitHub AZNAMIER Apache Maven Packages</name>
-	     <url>https://maven.pkg.github.com/aznamier/keycloak-event-listener-rabbitmq</url>
+	     <name>GitHub tributech-solutions Apache Maven Packages</name>
+	     <url>https://maven.pkg.github.com/tributech-solutions/keycloak-event-listener-rabbitmq</url>
 	   </repository>
 	</distributionManagement>
 	
@@ -68,7 +68,7 @@
     </dependencies>
 
     <build>
-        <finalName>keycloak-to-rabbit</finalName>
+        <finalName>keycloak-to-rabbit-tributech-mod</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqEventListenerProviderFactory.java
+++ b/src/main/java/com/github/aznamier/keycloak/event/provider/RabbitMqEventListenerProviderFactory.java
@@ -12,7 +12,7 @@ public class RabbitMqEventListenerProviderFactory implements EventListenerProvid
 
 	@Override
 	public EventListenerProvider create(KeycloakSession session) {
-		return new RabbitMqEventListenerProvider(cfg);
+		return new RabbitMqEventListenerProvider(cfg, session);
 	}
 
 	@Override


### PR DESCRIPTION
* for update profile and register events triggered by keycloak REST API
* enrich event with addtional user info to allow more usecases

To provide similar event data as it has been added at the following PR but only for AccountFormService not AccountRestService:
https://github.com/keycloak/keycloak/pull/7495

AccountFormService.java:
https://github.com/keycloak/keycloak/blob/a36fafe04e9eaee2a156af3700c022faa2223483/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java#L372

AccountRestService.java (missing data at events):
https://github.com/keycloak/keycloak/blob/a36fafe04e9eaee2a156af3700c022faa2223483/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java#L159

UpdateProfile.java
https://github.com/keycloak/keycloak/blob/a36fafe04e9eaee2a156af3700c022faa2223483/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateProfile.java#L69

https://github.com/keycloak/keycloak/blob/e56bd9d8b8cbaf4600e6bcc5e28c962eb561d74c/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java#L208
